### PR TITLE
Use environment variables to forward API calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ build: rsa 			## build the app binaries
 	go build -o ./tmp ./...
 
 test: build 		## build and test the module packages
-	export PRIVATE_KEY="../tmp/id_rsa" && export SERVER_CERT="../tmp/server.crt" \
-		&& go test ./...
+	export KAREN_IP="localhost" && export PRIVATE_KEY="../tmp/id_rsa" && \
+		export SERVER_CERT="../tmp/server.crt" && go test ./...
 
 run: build 			## build and run the app binaries
-	export PRIVATE_KEY="tmp/id_rsa" && export SERVER_CERT="tmp/server.crt" \
-		&& ./tmp/app
+	export KAREN_IP="localhost" && export PRIVATE_KEY="tmp/id_rsa" && \
+		export SERVER_CERT="tmp/server.crt" && ./tmp/app
 
 docker: rsa 		## build the docker image
 	docker build -t $(APP_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ build: rsa 			## build the app binaries
 	go build -o ./tmp ./...
 
 test: build 		## build and test the module packages
-	export KAREN_IP="localhost" && export PRIVATE_KEY="../tmp/id_rsa" && \
+	export KAREN_HOST="localhost" && export PRIVATE_KEY="../tmp/id_rsa" && \
 		export SERVER_CERT="../tmp/server.crt" && go test ./...
 
 run: build 			## build and run the app binaries
-	export KAREN_IP="localhost" && export PRIVATE_KEY="tmp/id_rsa" && \
+	export KAREN_HOST="localhost" && export PRIVATE_KEY="tmp/id_rsa" && \
 		export SERVER_CERT="tmp/server.crt" && ./tmp/app
 
 docker: rsa 		## build the docker image

--- a/app/server.go
+++ b/app/server.go
@@ -27,7 +27,7 @@ func main() {
 		RC: &http.Client{
 			Timeout: time.Second * 10,
 		},
-		AppIPs: make(map[string]string),
+		Hosts: make(map[string]string),
 	}
 
 	privateKeyPath := os.Getenv("PRIVATE_KEY")
@@ -49,9 +49,9 @@ func main() {
 	}
 
 	// /* Uncomment this to work w/o karen
-	e.AppIPs["karen"] = os.Getenv("KAREN_IP")
-	if e.AppIPs["karen"] == "" {
-		log.Fatal(`required "KAREN_IP" environment variable not set`)
+	e.Hosts["karen"] = os.Getenv("KAREN_HOST")
+	if e.Hosts["karen"] == "" {
+		log.Fatal(`required "KAREN_HOST" environment variable not set`)
 	}
 	// */ // Uncomment this to work w/o karen
 

--- a/app/server.go
+++ b/app/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"github.com/gorilla/mux"
 	"github.com/schramm-famm/heimdall/handlers"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -20,6 +21,15 @@ func makeServerFromMux(r *mux.Router) *http.Server {
 }
 
 func main() {
+	var err error
+
+	e := &handlers.Env{
+		RC: &http.Client{
+			Timeout: time.Second * 10,
+		},
+		AppIPs: make(map[string]string),
+	}
+
 	privateKeyPath := os.Getenv("PRIVATE_KEY")
 	if privateKeyPath == "" {
 		privateKeyPath = "id_rsa"
@@ -30,12 +40,27 @@ func main() {
 		certPath = "server.cert"
 	}
 
+	if e.PrivateKey, err = ioutil.ReadFile(privateKeyPath); err != nil {
+		log.Fatal(`Failed to read private key file: `, err)
+	}
+
+	if e.PublicKey, err = ioutil.ReadFile(privateKeyPath + ".pub"); err != nil {
+		log.Fatal(`Failed to read public key file: `, err)
+	}
+
+	// /* Uncomment this to work w/o karen
+	e.AppIPs["karen"] = os.Getenv("KAREN_IP")
+	if e.AppIPs["karen"] == "" {
+		log.Fatal(`required "KAREN_IP" environment variable not set`)
+	}
+	// */ // Uncomment this to work w/o karen
+
 	httpsMux := mux.NewRouter()
 	httpsMux.HandleFunc(
 		"/heimdall/v1/token",
-		handlers.PostTokenHandler,
+		e.PostTokenHandler,
 	).Methods("POST")
-	httpsMux.PathPrefix("/").Handler(http.HandlerFunc(handlers.ReqHandler))
+	httpsMux.PathPrefix("/").Handler(http.HandlerFunc(e.ReqHandler))
 
 	httpsSrv := makeServerFromMux(httpsMux)
 	httpsSrv.Addr = ":443"
@@ -52,6 +77,7 @@ func main() {
 	}
 	httpsSrv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 
+	e.RC.Transport = &http.Transport{TLSClientConfig: httpsSrv.TLSConfig}
 	// Start HTTPS server
 	go func() {
 		log.Fatal(httpsSrv.ListenAndServeTLS(certPath, privateKeyPath))

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,7 +19,7 @@ type Env struct {
 	RC         *http.Client
 	PrivateKey []byte
 	PublicKey  []byte
-	AppIPs     map[string]string
+	Hosts      map[string]string
 }
 
 const (
@@ -61,7 +61,7 @@ func (e *Env) createToken(user models.User) (string, error) {
 
 func (e *Env) PostTokenHandler(w http.ResponseWriter, r *http.Request) {
 	// /* Uncomment this for token generation to work w/o karen
-	resp, err := e.RC.Post("http://"+e.AppIPs["karen"]+authRoute, "application/json", r.Body)
+	resp, err := e.RC.Post("http://"+e.Hosts["karen"]+authRoute, "application/json", r.Body)
 	if err != nil {
 		log.Printf(`Failed to send request to "%s": %s\n`, authRoute, err.Error())
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -107,20 +107,20 @@ func (e *Env) forwardRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if app IP address is alreaday cached
-	if _, ok := e.AppIPs[appName]; !ok {
+	// Check if app host is already cached
+	if _, ok := e.Hosts[appName]; !ok {
 		// Get the IP address from the environment variable
-		appIP := os.Getenv(appName)
-		if appIP == "" {
+		appHost := os.Getenv(appName)
+		if appHost == "" {
 			log.Printf(`Service "%s" could not be found`, appName)
 			http.Error(w, "Not Found", http.StatusNotFound)
 			return
 		}
-		e.AppIPs[appName] = appIP
+		e.Hosts[appName] = appHost
 	}
 
 	// Build the new URL
-	if newURL, err := url.Parse("http://" + e.AppIPs[appName] + urlString); err != nil {
+	if newURL, err := url.Parse("http://" + e.Hosts[appName] + urlString); err != nil {
 		log.Println("Failed to create new URL: ", err.Error())
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -91,7 +91,7 @@ func TestPostTokenHandler(t *testing.T) {
 				PrivateKey: privateKey,
 				PublicKey:  publicKey,
 				RC:         server.Client(),
-				AppIPs:     map[string]string{"karen": strings.TrimPrefix(server.URL, "http://")},
+				Hosts:      map[string]string{"karen": strings.TrimPrefix(server.URL, "http://")},
 			}
 
 			rBody, _ := json.Marshal(test.ReqBody)
@@ -178,7 +178,7 @@ func TestReqHandler(t *testing.T) {
 
 			re := regexp.MustCompile("[^/]+")
 			appName := re.FindString(test.Path)
-			e.AppIPs = map[string]string{appName: strings.TrimPrefix(server.URL, "http://")}
+			e.Hosts = map[string]string{appName: strings.TrimPrefix(server.URL, "http://")}
 
 			r := httptest.NewRequest(test.Method, test.Path, bytes.NewReader([]byte{}))
 			r.Header = http.Header{}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -4,13 +4,32 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/schramm-famm/heimdall/models"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 )
 
-func resetVariables() {
-	authRoute = "http://karen/api/auth"
+var (
+	privateKey []byte
+	publicKey  []byte
+)
+
+func init() {
+	var err error
+	privateKeyPath := os.Getenv("PRIVATE_KEY")
+
+	if privateKey, err = ioutil.ReadFile(privateKeyPath); err != nil {
+		log.Fatal(`Failed to read private key file: `, err)
+	}
+
+	if publicKey, err = ioutil.ReadFile(privateKeyPath + ".pub"); err != nil {
+		log.Fatal(`Failed to read public key file: `, err)
+	}
 }
 
 func TestPostTokenHandler(t *testing.T) {
@@ -47,8 +66,6 @@ func TestPostTokenHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			resetVariables()
-
 			mockAuthHandler := func(w http.ResponseWriter, r *http.Request) {
 				userBody := models.User{}
 				if err := json.NewDecoder(r.Body).Decode(&userBody); err != nil {
@@ -70,14 +87,18 @@ func TestPostTokenHandler(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(mockAuthHandler))
 			defer server.Close()
 
-			rc = server.Client()
-			authRoute = server.URL
+			e := &Env{
+				PrivateKey: privateKey,
+				PublicKey:  publicKey,
+				RC:         server.Client(),
+				AppIPs:     map[string]string{"karen": strings.TrimPrefix(server.URL, "http://")},
+			}
 
 			rBody, _ := json.Marshal(test.ReqBody)
 			r := httptest.NewRequest("POST", "/heimdall/v1/token", bytes.NewReader([]byte(rBody)))
 			w := httptest.NewRecorder()
 
-			PostTokenHandler(w, r)
+			e.PostTokenHandler(w, r)
 
 			if w.Code != test.AuthStatusCode {
 				t.Errorf("Response has incorrect status code, expected status code %d, got %d", test.AuthStatusCode, w.Code)
@@ -99,7 +120,12 @@ func TestPostTokenHandler(t *testing.T) {
 }
 
 func TestReqHandler(t *testing.T) {
-	validToken, err := createToken(models.User{})
+	e := &Env{
+		PrivateKey: privateKey,
+		PublicKey:  publicKey,
+	}
+
+	validToken, err := e.createToken(models.User{})
 	if err != nil {
 		t.Error("Failed to generate valid token: " + err.Error())
 	}
@@ -109,28 +135,33 @@ func TestReqHandler(t *testing.T) {
 		StatusCode int
 		Header     map[string]string
 		Path       string
+		Method     string
 	}{
 		{
 			Name:       "Successful route validation",
 			StatusCode: http.StatusOK,
 			Header:     map[string]string{"Authorization": "Bearer " + validToken},
 			Path:       "/karen",
+			Method:     http.MethodGet,
 		},
 		{
 			Name:       "Successful access to whitelisted route",
 			StatusCode: http.StatusOK,
-			Path:       "/login",
+			Path:       "/karen/v1/users",
+			Method:     http.MethodPost,
 		},
 		{
 			Name:       "Unsuccessful route validation without Authorization header",
 			StatusCode: http.StatusUnauthorized,
 			Path:       "/karen",
+			Method:     http.MethodPost,
 		},
 		{
 			Name:       "Unsuccessful route validation with invalid token",
 			StatusCode: http.StatusUnauthorized,
 			Header:     map[string]string{"Authorization": "Bearer invalid"},
 			Path:       "/karen",
+			Method:     http.MethodPost,
 		},
 	}
 
@@ -143,16 +174,20 @@ func TestReqHandler(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(mockHandler))
 			defer server.Close()
 
-			rc = server.Client()
+			e.RC = server.Client()
 
-			r := httptest.NewRequest("GET", server.URL+test.Path, bytes.NewReader([]byte{}))
+			re := regexp.MustCompile("[^/]+")
+			appName := re.FindString(test.Path)
+			e.AppIPs = map[string]string{appName: strings.TrimPrefix(server.URL, "http://")}
+
+			r := httptest.NewRequest(test.Method, test.Path, bytes.NewReader([]byte{}))
 			r.Header = http.Header{}
 			for key, val := range test.Header {
 				r.Header.Set(key, val)
 			}
 			w := httptest.NewRecorder()
 
-			ReqHandler(w, r)
+			e.ReqHandler(w, r)
 
 			if w.Code != test.StatusCode {
 				t.Errorf("Response has incorrect status code, expected status code %d, got %d", test.StatusCode, w.Code)


### PR DESCRIPTION
* Use Env struct to store rest client and cache service IP addresses and
RSA keys
* Implement IP address lookup for services when heimdall needs to
forward the request
* Update handler unit tests to reflect changes
* Update Makefile to include a default value for the KAREN_IP environment
variable
* Fix some error responses to hide internal errors from the client

Resolves #12 .