### PR TITLE
Add terraform module and initial config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ heimdall/
     |-- handlers_test.go
 |-- models/
     |-- models.go
+|-- terraform/
+    |-- main.tf
+    |-- variables.tf
+    |-- modules/
+        |-- main.tf
+        |-- variables.tf
 ```
 
 #### Dockerfile
@@ -86,6 +92,22 @@ defined in `handlers.go`.
 
 #### models.go
 This files contains the definitions of the `User` and `TokenClaims` structs.
+
+### Terraform
+To deploy `heimdall` and its direct dependencies in AWS, use `terraform`:
+1. Change directories to the `terraform/` directory.
+2. Create a file in the `terraform/` directory called `terraform.tfvars` and fill it out like this:
+```
+name = "WHATEVER_UNIQUE_NAME_YOU_WANT"
+access_key = "YOUR_AWS_ACCESS_KEY_ID"
+secret_key = "YOUR_AWS_SECRET_ACCESS_KEY"
+```
+3. Run `terraform init` to initialize the Terraform working directory.
+4. Run `terraform plan` to see what resources will be created and then `terraform apply` to create the resources. Enter
+`yes` when prompted by Terraform.
+5. Once the previous command is done running, the AWS resources should now be visible in the AWS console (UI) and ready
+to be used for development/testing. Once you're done using the resources, run `terraform destroy`. Enter `yes` when
+prompted by Terraform.
 
 ### Developer Process
 The RSA private and public keys are generated whenever the app is built and is

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
+}
+
+module "ecs_base" {
+  source = "github.com/schramm-famm/bespin//modules/ecs_base"
+  name   = var.name
+}
+
+module "ecs_cluster" {
+  source                  = "github.com/schramm-famm/bespin//modules/ecs_cluster"
+  name                    = var.name
+  security_group_id       = module.ecs_base.vpc_default_security_group_id
+  subnets                 = module.ecs_base.vpc_public_subnets
+  ec2_instance_profile_id = module.ecs_base.ecs_instance_profile_id
+}
+
+module "heimdall" {
+  source        = "./modules/heimdall"
+  name          = var.name
+  container_tag = "1.0.0"
+  cluster_id    = module.ecs_cluster.cluster_id
+}

--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -16,18 +16,8 @@ resource "aws_ecs_task_definition" "heimdall" {
     "essential": true,
     "portMappings": [
       {
-        "containerPort": 8080,
-        "hostPort": 8080,
-        "protocol": "tcp"
-      },
-      {
         "containerPort": 443,
         "hostPort": 443,
-        "protocol": "tcp"
-      },
-      {
-        "containerPort": 80,
-        "hostPort": 80,
         "protocol": "tcp"
       }
     ]

--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -1,0 +1,45 @@
+resource "aws_cloudwatch_log_group" "heimdall" {
+  name              = "${var.name}_heimdall"
+  retention_in_days = 1
+}
+
+resource "aws_ecs_task_definition" "heimdall" {
+  family = "${var.name}_heimdall"
+
+  container_definitions = <<EOF
+[
+  {
+    "name": "${var.name}_heimdall",
+    "image": "343660461351.dkr.ecr.us-east-2.amazonaws.com/heimdall:${var.container_tag}",
+    "cpu": 10,
+    "memory": 128,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 8080,
+        "protocol": "tcp"
+      },
+      {
+        "containerPort": 443,
+        "hostPort": 443,
+        "protocol": "tcp"
+      },
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      }
+    ]
+  }
+]
+EOF
+}
+
+resource "aws_ecs_service" "heimdall" {
+  name = "${var.name}_heimdall"
+  cluster = var.cluster_id
+  task_definition = aws_ecs_task_definition.heimdall.arn
+
+  desired_count = 1
+}

--- a/terraform/modules/heimdall/variables.tf
+++ b/terraform/modules/heimdall/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "container_tag" {
+  type        = string
+  description = "Tag of the heimdall container in the registry to be used"
+  default     = "latest"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "ID of the ECS cluster that the heimdall service will run in"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,25 @@
+variable "name" {
+  type        = string
+  description = "Name used to identify resources"
+}
+
+variable "access_key" {
+  type        = string
+  description = "AWS access key ID"
+}
+
+variable "secret_key" {
+  type        = string
+  description = "AWS secret access key"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy where resources will be deployed"
+  default     = "us-east-2"
+}
+
+variable "key_name" {
+  type        = string
+  description = "AWS key pair name for SSH access to EC2 instances"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,8 +18,3 @@ variable "region" {
   description = "AWS region to deploy where resources will be deployed"
   default     = "us-east-2"
 }
-
-variable "key_name" {
-  type        = string
-  description = "AWS key pair name for SSH access to EC2 instances"
-}


### PR DESCRIPTION
This repository defines the `heimdall` terraform module that can be called by terraform config in other repositories.

It also uses the `heimdall` module itself along with other terraform config to setup a partial "integration" environment just with `heimdall` and its direct dependencies in AWS for testing.