### PR TITLE
Move token authentication API to an HTTP server

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -130,6 +130,7 @@ func main() {
 	// Create and start internal HTTP server
 	httpMux := mux.NewRouter()
 	httpMux.HandleFunc("/heimdall/v1/token/auth", e.PostTokenAuthHandler).Methods("POST")
+	httpMux.Use(logging)
 	httpSrv := makeServerFromMux(httpMux)
 	httpSrv.Addr = ":80"
 	log.Fatal(httpSrv.ListenAndServe())


### PR DESCRIPTION
This server listens on port 80 and should only be exposed to internal
services that need to verify tokens.