### PR TITLE
Add Karen Terraform to integration environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ docker-run: docker 	## start the built docker image in a container
 		-e PATCHES_HOST=$(PATCHES_HOST) -e PRIVATE_KEY="id_rsa" \
 		--name $(APP_NAME) $(REGISTRY)/$(APP_NAME):$(TAG)
 
+docker-push: tmp docker
+	docker push $(REGISTRY)/$(APP_NAME):$(TAG)
+
 .PHONY: clean
 clean: 				## remove tmp/ and old docker images
 	rm -rf tmp

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ docker-run: docker 	## start the built docker image in a container
 		-e PATCHES_HOST=$(PATCHES_HOST) -e PRIVATE_KEY="id_rsa" \
 		--name $(APP_NAME) $(REGISTRY)/$(APP_NAME):$(TAG)
 
-docker-push: tmp docker
+docker-push: docker
 	docker push $(REGISTRY)/$(APP_NAME):$(TAG)
 
 .PHONY: clean

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,15 +16,15 @@ resource "aws_security_group" "backend" {
   vpc_id      = module.ecs_base.vpc_id
 
   ingress {
-    from_port   = 80
-    to_port     = 80
+    from_port   = 8080
+    to_port     = 8081
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-    from_port   = 8080
-    to_port     = 8081
+    from_port   = 80
+    to_port     = 80
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,8 +5,9 @@ provider "aws" {
 }
 
 module "ecs_base" {
-  source = "github.com/schramm-famm/bespin//modules/ecs_base"
-  name   = var.name
+  source             = "github.com/schramm-famm/bespin//modules/ecs_base"
+  name               = var.name
+  enable_nat_gateway = true
 }
 
 resource "aws_security_group" "heimdall" {
@@ -36,22 +37,77 @@ resource "aws_security_group" "heimdall" {
   }
 }
 
-module "ecs_cluster" {
+resource "aws_security_group" "karen" {
+  name        = "${var.name}_allow_heimdall"
+  description = "Allow traffic from heimdall"
+  vpc_id      = module.ecs_base.vpc_id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.heimdall.id]
+    self            = true # Allow micro-services to talk to each-other
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "public_ecs_cluster" {
   source                  = "github.com/schramm-famm/bespin//modules/ecs_cluster"
-  name                    = var.name
+  name                    = "${var.name}-public"
   security_group_ids      = [aws_security_group.heimdall.id]
   subnets                 = module.ecs_base.vpc_public_subnets
+  ec2_instance_profile_id = module.ecs_base.ecs_instance_profile_id
+}
+
+module "private_ecs_cluster" {
+  source                  = "github.com/schramm-famm/bespin//modules/ecs_cluster"
+  name                    = "${var.name}-private"
+  security_group_ids      = [aws_security_group.karen.id]
+  subnets                 = module.ecs_base.vpc_private_subnets
   ec2_instance_profile_id = module.ecs_base.ecs_instance_profile_id
 }
 
 module "heimdall" {
   source           = "./modules/heimdall"
   name             = var.name
-  container_tag    = var.container_tag
-  cluster_id       = module.ecs_cluster.cluster_id
+  container_tag    = var.heimdall_container_tag
+  cluster_id       = module.public_ecs_cluster.cluster_id
   vpc_id           = module.ecs_base.vpc_id
   security_groups  = [aws_security_group.heimdall.id]
   subnets          = module.ecs_base.vpc_public_subnets
   private_key_cert = var.private_key_cert
   cert             = var.cert
+  karen_endpoint   = module.karen.elb_dns_name
+}
+
+module "karen" {
+  source          = "github.com/schramm-famm/karen//terraform/modules/karen"
+  name            = var.name
+  container_tag   = var.karen_container_tag
+  cluster_id      = module.private_ecs_cluster.cluster_id
+  security_groups = [aws_security_group.karen.id]
+  subnets         = module.ecs_base.vpc_private_subnets
+  internal        = true
+  db_location     = module.rds_instance.db_endpoint
+  db_username     = var.rds_username
+  db_password     = var.rds_password
+}
+
+module "rds_instance" {
+  source          = "github.com/schramm-famm/bespin//modules/rds_instance"
+  name            = var.name
+  engine          = "mariadb"
+  engine_version  = "10.2.21"
+  port            = 3306
+  master_username = var.rds_username
+  master_password = var.rds_password
+  vpc_id          = module.ecs_base.vpc_id
+  subnet_ids      = module.ecs_base.vpc_private_subnets
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,7 +54,9 @@ module "heimdall" {
   subnets          = module.ecs_base.vpc_public_subnets
   private_key_cert = var.private_key_cert
   cert             = var.cert
-  karen_endpoint   = module.karen.elb_dns_name
+  endpoints = {
+    "karen" = module.karen.elb_dns_name
+  }
 }
 
 module "karen" {

--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -31,7 +31,7 @@ resource "aws_ecs_task_definition" "heimdall" {
       %{for service, endpoint in var.endpoints}
       ,
       {
-        "name": "${upper(service)}_HOST",
+        "name": "${replace(upper(service), "-", "_")}_HOST",
         "value": "${endpoint}"
       }
       %{endfor}

--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -27,11 +27,14 @@ resource "aws_ecs_task_definition" "heimdall" {
       {
         "name": "PRIVATE_KEY",
         "value": "${var.private_key_jwt}"
-      },
-      {
-        "name": "KAREN_HOST",
-        "value": "${var.karen_endpoint}"
       }
+      %{for service, endpoint in var.endpoints}
+      ,
+      {
+        "name": "${upper(service)}_HOST",
+        "value": "${endpoint}"
+      }
+      %{endfor}
     ],
     "portMappings": [
       {

--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -30,7 +30,7 @@ resource "aws_ecs_task_definition" "heimdall" {
       },
       {
         "name": "KAREN_HOST",
-        "value": "localhost:80"
+        "value": "${var.karen_endpoint}"
       }
     ],
     "portMappings": [
@@ -65,60 +65,60 @@ resource "aws_lb" "heimdall-external" {
 }
 
 resource "aws_lb_target_group" "heimdall-internal" {
-  name        = "${var.name}-heimdall-internal"
-  port        = 8080
-  protocol    = "TCP"
-  vpc_id      = "${var.vpc_id}"
+  name     = "${var.name}-heimdall-internal"
+  port     = 8080
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
 
   stickiness {
-      enabled = false
-      type = "lb_cookie"
+    enabled = false
+    type    = "lb_cookie"
   }
 
-  depends_on = ["aws_lb.heimdall-internal"]
+  depends_on = [aws_lb.heimdall-internal]
 }
 
 resource "aws_lb_target_group" "heimdall-external" {
-  name        = "${var.name}-heimdall-external"
-  port        = 80
-  protocol    = "TCP"
-  vpc_id      = "${var.vpc_id}"
+  name     = "${var.name}-heimdall-external"
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = var.vpc_id
 
   stickiness {
-      enabled = false
-      type = "lb_cookie"
+    enabled = false
+    type    = "lb_cookie"
   }
 
-  depends_on = ["aws_lb.heimdall-external"]
+  depends_on = [aws_lb.heimdall-external]
 }
 
 resource "aws_lb_listener" "heimdall-internal" {
-  load_balancer_arn = "${aws_lb.heimdall-internal.arn}"
+  load_balancer_arn = aws_lb.heimdall-internal.arn
   port              = "80"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.heimdall-internal.arn}"
+    target_group_arn = aws_lb_target_group.heimdall-internal.arn
   }
 }
 
 resource "aws_iam_server_certificate" "heimdall" {
   name             = "${var.name}-heimdall"
-  certificate_body = "${file("${var.cert}")}"
-  private_key      = "${file("${var.private_key_cert}")}"
+  certificate_body = file(var.cert)
+  private_key      = file(var.private_key_cert)
 }
 
 resource "aws_lb_listener" "heimdall-external" {
-  load_balancer_arn = "${aws_lb.heimdall-external.arn}"
+  load_balancer_arn = aws_lb.heimdall-external.arn
   port              = "443"
   protocol          = "TLS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "${aws_iam_server_certificate.heimdall.arn}"
+  certificate_arn   = aws_iam_server_certificate.heimdall.arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.heimdall-external.arn}"
+    target_group_arn = aws_lb_target_group.heimdall-external.arn
   }
 }
 
@@ -130,13 +130,13 @@ resource "aws_ecs_service" "heimdall" {
   load_balancer {
     container_name   = "${var.name}_heimdall"
     container_port   = 8080
-    target_group_arn = "${aws_lb_target_group.heimdall-internal.id}"
+    target_group_arn = aws_lb_target_group.heimdall-internal.id
   }
 
   load_balancer {
     container_name   = "${var.name}_heimdall"
     container_port   = 80
-    target_group_arn = "${aws_lb_target_group.heimdall-external.id}"
+    target_group_arn = aws_lb_target_group.heimdall-external.id
   }
 
   desired_count = 1

--- a/terraform/modules/heimdall/variables.tf
+++ b/terraform/modules/heimdall/variables.tf
@@ -44,3 +44,8 @@ variable "cert" {
   type        = string
   description = "Local path to the TLS certificate"
 }
+
+variable "karen_endpoint" {
+  type        = string
+  description = "Endpoint for accessing the karen service"
+}

--- a/terraform/modules/heimdall/variables.tf
+++ b/terraform/modules/heimdall/variables.tf
@@ -40,7 +40,7 @@ variable "cert" {
   description = "Local path to the TLS certificate"
 }
 
-variable "karen_endpoint" {
-  type        = string
-  description = "Endpoint for accessing the karen service"
+variable "endpoints" {
+  type        = map(string)
+  description = "Endpoints for accessing backend services {'service-name' = 'endpoint'}"
 }

--- a/terraform/modules/heimdall/variables.tf
+++ b/terraform/modules/heimdall/variables.tf
@@ -14,11 +14,6 @@ variable "cluster_id" {
   description = "ID of the ECS cluster that the heimdall service will run in"
 }
 
-variable "security_groups" {
-  type        = list(string)
-  description = "VPC security groups for the heimdall service load balancers"
-}
-
 variable "subnets" {
   type        = list(string)
   description = "VPC subnets for the heimdall service load balancers"

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,3 @@
+output "host" {
+  value = module.heimdall.external_lb_dns_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,9 +19,15 @@ variable "region" {
   default     = "us-east-2"
 }
 
-variable "container_tag" {
+variable "heimdall_container_tag" {
   type        = string
   description = "Tag of the heimdall container in the registry to be used"
+  default     = "latest"
+}
+
+variable "karen_container_tag" {
+  type        = string
+  description = "Tag of the karen container in the registry to be used"
   default     = "latest"
 }
 
@@ -39,4 +45,14 @@ variable "private_key_cert" {
 variable "cert" {
   type        = string
   description = "Local path to the TLS certificate"
+}
+
+variable "rds_username" {
+  type        = string
+  description = "Username for the master RDS user"
+}
+
+variable "rds_password" {
+  type        = string
+  description = "Password for the master RDS user"
 }


### PR DESCRIPTION
Resolves #19 

Used the `karen` Terraform module and the `rds_instance` Terraform module. `heimdall` and `karen` can talk to each other, so things are looking good!

I made it so that both `heimdall` and `karen` are deployed on the private subnet, so `heimdall` is now only exposed publicly through the internet-facing network load balancer.

Also fixed some formatting and styling here and there.