### PR TITLE
Run Heimdall in its own ECS cluster

### DIFF
--- a/terraform/modules/heimdall/main.tf
+++ b/terraform/modules/heimdall/main.tf
@@ -57,14 +57,14 @@ resource "aws_lb" "heimdall-internal" {
   name               = "${var.name}-heimdall-internal"
   internal           = true
   load_balancer_type = "network"
-  subnets            = var.subnets
+  subnets            = var.internal_lb_subnets
 }
 
 resource "aws_lb" "heimdall-external" {
   name               = "${var.name}-heimdall-external"
   internal           = false
   load_balancer_type = "network"
-  subnets            = var.subnets
+  subnets            = var.external_lb_subnets
 }
 
 resource "aws_lb_target_group" "heimdall-internal" {

--- a/terraform/modules/heimdall/variables.tf
+++ b/terraform/modules/heimdall/variables.tf
@@ -14,9 +14,14 @@ variable "cluster_id" {
   description = "ID of the ECS cluster that the heimdall service will run in"
 }
 
-variable "subnets" {
+variable "external_lb_subnets" {
   type        = list(string)
-  description = "VPC subnets for the heimdall service load balancers"
+  description = "VPC subnets for the external heimdall service load balancers"
+}
+
+variable "internal_lb_subnets" {
+  type        = list(string)
+  description = "VPC subnets for the internal heimdall service load balancers"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Fixes the issue of other services (`patches` specifically) not being able
to call `heimdall`'s internal HTTP server when running on the same
instance.

There are no services in this integration environment that need this
fix, but this is how `heimdall` will be deployed elsewhere, so it's better
to have it the same here.

Also made it so that you can specify separate subnets for the internal
and external load balancers for the `heimdall` module.